### PR TITLE
If css maps are disabled, creating an empty file is unnecessary

### DIFF
--- a/src/compiler/sass.js
+++ b/src/compiler/sass.js
@@ -76,9 +76,12 @@ async function compile(file, ctx, targetConfig, rc) {
   css = css.toString()
   css = await postProcess(file, css, rc, postprocess)
 
+  // prepare write files
+  const outWrite = [await write(outfile, css)]
+  if(map) {
+    outWrite.push(await write(outmap, map))
+  }
+
   // write files
-  return [
-    await write(outfile, css),
-    await write(outmap, map)
-  ]
+  return outWrite
 }


### PR DESCRIPTION
If css maps are disabled, creating an empty file is unnecessary :)